### PR TITLE
chore(package.json): Added missing dev dep: ts-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1013,7 +1013,8 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -1573,7 +1574,8 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "25.2.6",
@@ -5013,6 +5015,7 @@
       "version": "8.10.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
       "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
@@ -5325,7 +5328,8 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "@types/node": "^14.0.27"
+        "@types/node": "^14.0.27",
+        "ts-node": "8.10.2"
     },
     "dependencies": {
         "@types/jest": "^26.0.10",
         "jest": "^26.4.1",
         "ts-jest": "^26.2.0",
-        "ts-node": "^8.10.2",
         "typescript": "^3.9.7"
     },
     "jest": {


### PR DESCRIPTION
I ran `docker-compose up` and got a message about typescript not being installed.
This PR adds `ts-node` to the dev dependencies so it can be used within a docker container.

Before
 ```
Successfully built 84cdc48e990f
Successfully tagged vim-deathmatch_server:latest
Recreating vim-deathmatch_server_1 ... done
Attaching to vim-deathmatch_server_1
server_1  | npx: installed 8 in 1.713s
server_1  | Cannot find module 'typescript'
server_1  | Require stack:
server_1  | - /root/.npm/_npx/1/lib/node_modules/ts-node/dist/index.js
server_1  | - /root/.npm/_npx/1/lib/node_modules/ts-node/dist/bin.js
vim-deathmatch_server_1 exited with code 1
```

After
```
vim-deathmatch$docker-compose up
Starting vim-deathmatch_server_1 ... done
Attaching to vim-deathmatch_server_1
server_1  | FILES
server_1  | server bound`
```